### PR TITLE
Missing Token Fetching for Dune V2

### DIFF
--- a/queries/missing-tokens-v2.sql
+++ b/queries/missing-tokens-v2.sql
@@ -1,0 +1,19 @@
+WITH
+-- This query can't yet be run via duneapi client,
+-- but the results can be fetched from the interface at: https://dune.com/queries/857522
+all_tokens as (
+    SELECT DISTINCT token FROM (
+        SELECT distinct(buyToken) as token
+        FROM gnosis_protocol_v2_ethereum.GPv2Settlement_evt_Trade
+        UNION
+        SELECT distinct(sellToken) as token
+        FROM gnosis_protocol_v2_ethereum.GPv2Settlement_evt_Trade
+    ) as _
+),
+missing_tokens as (
+    select token
+    from all_tokens
+    where token not in (select contract_address from tokens_ethereum.erc20)
+)
+
+SELECT * FROM missing_tokens

--- a/src/missing_tokens.py
+++ b/src/missing_tokens.py
@@ -1,7 +1,13 @@
+import argparse
+import csv
 import os
+from enum import Enum
+from typing import Optional
 
+import web3.exceptions
 from dotenv import load_dotenv
 from duneapi.api import DuneAPI
+from duneapi.file_io import File
 from duneapi.types import Address, DuneQuery, Network
 from duneapi.util import open_query
 from web3 import Web3
@@ -9,6 +15,11 @@ from web3 import Web3
 from web3.contract import ConciseContract as Factory
 
 from src.constants import ERC20_ABI
+
+
+class DuneVersion(Enum):
+    V1 = "1"
+    V2 = "2"
 
 
 class TokenDetails:
@@ -22,13 +33,24 @@ class TokenDetails:
         self.symbol = token_contract.symbol()
         self.decimals = token_contract.decimals()
 
-    def __str__(self):
-        address_bytea = f"\\\\x{self.address[2:]}"
-        return f"{address_bytea}\t{self.symbol}\t{self.decimals}"
+    def to_str(self, version: DuneVersion):
+        if version == DuneVersion.V1:
+            address_bytea = f"\\\\x{self.address[2:]}"
+            return f"{address_bytea}\t{self.symbol}\t{self.decimals}"
+        if version == DuneVersion.V2:
+            return f"('{self.address.lower()}', '{self.symbol}', {self.decimals})"
+        raise ValueError(f"Invalid DuneVersion {version}")
 
 
-def fetch_missing_tokens(dune: DuneAPI) -> list[Address]:
+def fetch_missing_tokens(dune: DuneAPI, file: Optional[File]) -> list[Address]:
     """Initiates and executes Dune query for affiliate data on given month"""
+    if file:
+        # Until we can fetch from DuneV2, this will have to be a file.
+        print(f"Loading missing tokens from: {file.filename()}")
+        with open(file.filename(), "r") as csv_file:
+            return [Address(row["token"]) for row in csv.DictReader(csv_file)]
+
+    print("Getting missing tokens from: https://dune.com/queries/236085")
     query = DuneQuery.from_environment(
         raw_sql=open_query("./queries/missing-tokens.sql"),
         name=f"Missing Tokens",
@@ -41,16 +63,32 @@ def fetch_missing_tokens(dune: DuneAPI) -> list[Address]:
 
 if __name__ == "__main__":
     load_dotenv()
+    parser = argparse.ArgumentParser("Missing Tokens")
+    parser.add_argument(
+        "--token-file",
+        type=str,
+        help="CSV File to read token data from (this is for Dune V2)",
+    )
+    args = parser.parse_args()
+
+    token_file = File(args.token_file) if args.token_file else None
+    # We only supply a token file for Dune V2.
+    dune_version = DuneVersion(1) if not token_file else DuneVersion(2)
+
     w3 = Web3(
         Web3.HTTPProvider(f"https://mainnet.infura.io/v3/{os.environ['INFURA_KEY']}")
     )
     dune_conn = DuneAPI.new_from_environment()
-    print("Getting missing tokens from: https://dune.com/queries/236085")
-    missing_tokens = fetch_missing_tokens(dune_conn)
+    missing_tokens = fetch_missing_tokens(dune_conn, file=token_file)
     if missing_tokens:
-        print(f"Found {len(missing_tokens)} missing tokens, fetching metadata...")
-        # TODO batch the eth_calls used to construct the token contracts.
-        token_details = [str(TokenDetails(address=t)) for t in missing_tokens]
-        print("\n".join(token_details))
+        print(f"Found {len(missing_tokens)} missing tokens, fetching metadata...\n")
+        token_details = []
+        for t in missing_tokens:
+            try:
+                # TODO batch the eth_calls used to construct the token contracts.
+                token_details.append(TokenDetails(address=t).to_str(dune_version))
+            except web3.exceptions.BadFunctionCallOutput as err:
+                print(f"Something wrong with token {t} - skipping.")
+        print(",\n".join(token_details))
     else:
         print("No missing tokens detected. Have a good day!")


### PR DESCRIPTION
We can't yet emulate the browser interactions and fetch from Dune's new platform, but they have requested that we simultaneously keep their erc20 tokens table up to date on both platforms. This PR changes the current token fetcher to their new format and allows us to pass a token file (downloaded in csv format from Dune V2) and get the token details to create a PR.

Here is the first token list update resulting from this script: https://github.com/duneanalytics/abstractions/pull/1236
The diff is pretty big so just look at this commit: https://github.com/duneanalytics/abstractions/pull/1236/commits/03b5dd8555f52576d74231aeb932d3d389b06151

# Test Plan

You can run this new route of the missing token script by adding the following argument:

```
python -m src.missing_tokens --token-file=mytokenfile.csv
```

Note that you need to create a file `mytokenfile.csv` in project root's `out` directory. Here is an example:

```
token
0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc
0x5bf2390a68ab7db7d27ae81894c4e22e669af236
0x15f2ed83abef5cdc462975310b958c237eae4710
```