### PR TITLE
% gas saved per batch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-duneapi==3.0.7
+duneapi==4.0.0
 python-dotenv==0.20.0
 PyYAML==6.0
 requests==2.28.0
@@ -7,3 +7,4 @@ web3==5.29.2
 psycopg2==2.9.3
 SQLAlchemy==1.4.37
 pandas==1.4.3
+click==8.1.3

--- a/src/gas_saved.py
+++ b/src/gas_saved.py
@@ -1,0 +1,46 @@
+import os
+
+import click
+import pandas as pd
+from dotenv import load_dotenv
+from web3 import Web3
+
+from src.db.pg_client import pg_engine
+
+
+@click.command()
+@click.option(
+    "--batch_tx_hash",
+    help="The transaction hash of the batch you want to see the % gas saved.",
+    type=str
+)
+def main(batch_tx_hash):
+    db_engine = pg_engine()
+    GAS_QUOTES_QUERY = f"""
+    SELECT orders.id::bytea, order_quotes.gas_amount, order_quotes.gas_price
+    FROM
+        solver_competitions,
+        jsonb_to_recordset(solver_competitions.json->'solutions'->-1->'orders') AS orders(id text)
+    LEFT JOIN order_quotes ON order_quotes.order_uid = ('\\' || LTRIM(orders.id::text, '0'))::bytea
+    WHERE
+      solver_competitions.tx_hash = '\\{batch_tx_hash[1:]}'
+    """
+    df_quotes = pd.read_sql(GAS_QUOTES_QUERY, db_engine)
+    load_dotenv()
+    w3 = Web3(
+        Web3.HTTPProvider(f"https://mainnet.infura.io/v3/{os.environ['INFURA_KEY']}")
+    )
+    tx = w3.eth.get_transaction_receipt(batch_tx_hash)
+    print(
+        f"Trades executed individually would have cost {df_quotes['gas_amount'].sum():.0f} gas."
+    )
+    print(f"Batch only used {tx.gasUsed} gas.")
+    print(
+        f"This resulted in {df_quotes['gas_amount'].sum() - tx.gasUsed:.0f} absolute gas saved and "
+        f"{(tx.gasUsed / df_quotes['gas_amount'].sum()) * 100:.2f}% decrease of gas."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gas_saved.py
+++ b/src/gas_saved.py
@@ -26,7 +26,8 @@ def main(batch_tx_hash):
       solver_competitions.tx_hash = '\\{batch_tx_hash[1:]}'
     """
     df_quotes = pd.read_sql(GAS_QUOTES_QUERY, db_engine)
-    # substract settlement_overhead Ref: https://cowservices.slack.com/archives/D03N1R15LNQ/p1661267135582219?thread_ts=1661257111.988999&cid=D03N1R15LNQ
+    # subtract settlement_overhead from price estimation
+    # Ref: https://github.com/cowprotocol/services/blob/fd5f7cf47a6afdff89b310b60b869dfc577ac7a7/crates/shared/src/price_estimation/gas.rs#L37
     df_quotes["gas_amount"] = df_quotes["gas_amount"].apply(lambda x: x - 106391)
     load_dotenv()
     w3 = Web3(

--- a/src/gas_saved.py
+++ b/src/gas_saved.py
@@ -26,6 +26,8 @@ def main(batch_tx_hash):
       solver_competitions.tx_hash = '\\{batch_tx_hash[1:]}'
     """
     df_quotes = pd.read_sql(GAS_QUOTES_QUERY, db_engine)
+    # substract settlement_overhead Ref: https://cowservices.slack.com/archives/D03N1R15LNQ/p1661267135582219?thread_ts=1661257111.988999&cid=D03N1R15LNQ
+    df_quotes["gas_amount"] = df_quotes["gas_amount"].apply(lambda x: x - 106391)
     load_dotenv()
     w3 = Web3(
         Web3.HTTPProvider(f"https://mainnet.infura.io/v3/{os.environ['INFURA_KEY']}")
@@ -37,7 +39,7 @@ def main(batch_tx_hash):
     print(f"Batch only used {tx.gasUsed} gas.")
     print(
         f"This resulted in {df_quotes['gas_amount'].sum() - tx.gasUsed:.0f} absolute gas saved and "
-        f"{(tx.gasUsed / df_quotes['gas_amount'].sum()) * 100:.2f}% decrease of gas."
+        f"{((df_quotes['gas_amount'].sum() - tx.gasUsed) / df_quotes['gas_amount'].sum()) * 100:.2f}% decrease of gas."
     )
     return 0
 

--- a/src/orderbook.py
+++ b/src/orderbook.py
@@ -1,4 +1,4 @@
-import pandas as pds
+import pandas as pd
 from duneapi.api import DuneAPI
 from duneapi.types import DuneQuery, Network
 import numpy as np
@@ -20,8 +20,8 @@ import time
 from sqlalchemy.engine import LegacyCursorResult
 from src.db.pg_client import pg_engine
 
-pds.options.display.max_colwidth = None
-pds.options.display.max_columns = None
+pd.options.display.max_colwidth = None
+pd.options.display.max_columns = None
 
 
 def timeit(f):
@@ -42,7 +42,7 @@ def bin_str(bytea: memoryview) -> str:
 
 def pandas_query(db: engine):
     print("Pandas: Basic")
-    df = pds.read_sql("select * from invalidations", db)
+    df = pd.read_sql("select * from invalidations", db)
     for uid in df.order_uid:
         print(bin_str(uid))
 
@@ -147,7 +147,7 @@ def query_dune(dune: DuneAPI, raw_query: str) -> DataFrame:
         parameters=[],
     )
     print("Querying Dune")
-    results = pds.DataFrame(dune.fetch(query))
+    results = pd.DataFrame(dune.fetch(query))
     print(f"Got {len(results)} results")
     return results
 
@@ -155,7 +155,7 @@ def query_dune(dune: DuneAPI, raw_query: str) -> DataFrame:
 @timeit
 def query_orderbook(db: engine, raw_query: str) -> DataFrame:
     print("Querying orderbook")
-    results = pds.read_sql(raw_query, db)
+    results = pd.read_sql(raw_query, db)
     print(f"Got {len(results)} results")
     return results
 
@@ -180,12 +180,12 @@ def order_fill_time(db: engine, dune: DuneAPI):
     """
     settlement_df = query_dune(dune, dune_query)
 
-    joined_df = pds.merge(
+    joined_df = pd.merge(
         creation_df, settlement_df, how="inner", left_on="uid", right_on="order_uid"
     )
 
-    start = pds.to_datetime(joined_df.creation_timestamp)
-    end = pds.to_datetime(joined_df.block_time)
+    start = pd.to_datetime(joined_df.creation_timestamp)
+    end = pd.to_datetime(joined_df.block_time)
     joined_df["wait_time"] = (end - start).dt.seconds * 60  # / np.timedelta64(1, "s")  # .dt.seconds / 60
     sorted_df = joined_df.sort_values(by=["wait_time"], ascending=False)
     # Exclude negative wait times (two different clocks)


### PR DESCRIPTION
A script to be able to calculate how much gas was saved by going for a transaction in batch mode compared to one by one transactions. Script takes estimates from `order_quotes` sums it up, and compares it to the gas cost of the batch on chain.

Example
```bash
python -m src.gas_saved --batch_tx_hash 0xe82cb97b6fe036fe8b866da62a1ac2d1a26b20dbdb99b6d2d1e3644c18eab77d
```