### PR TITLE
Multi Network Missing Tokens

### DIFF
--- a/src/missing_tokens.py
+++ b/src/missing_tokens.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 from dataclasses import dataclass
-from enum import Enum
 
 import web3.exceptions
 from dotenv import load_dotenv
@@ -13,14 +12,9 @@ from duneapi.types import Address
 from web3 import Web3
 
 from src.constants import ERC20_ABI
-from src.utils import Network
+from src.utils import Network, DuneVersion
 
 V1_QUERY = DuneQuery(name="V1: Missing Tokens", query_id=1317323)
-
-
-class DuneVersion(Enum):
-    V1 = "1"
-    V2 = "2"
 
 
 class TokenDetails:
@@ -59,7 +53,7 @@ class MissingTokenResults:
     v2: list[Address]
 
     def is_empty(self) -> bool:
-        return self.v1 is [] and self.v2 is []
+        return not self.v1 and not self.v2
 
     def get_all_tokens(self) -> set[Address]:
         return set(self.v1 + self.v2)

--- a/src/missing_tokens.py
+++ b/src/missing_tokens.py
@@ -26,7 +26,9 @@ class DuneVersion(Enum):
 class TokenDetails:
     def __init__(self, address: Address):
         self.address = Web3.toChecksumAddress(address.address)
-        if self.address == Web3.toChecksumAddress("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"):
+        if self.address == Web3.toChecksumAddress(
+            "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
+        ):
             self.symbol = "ETH"
             self.decimals = 18
         else:
@@ -34,7 +36,7 @@ class TokenDetails:
             self.symbol = token_contract.caller.symbol()
             self.decimals = token_contract.caller.decimals()
 
-    def to_str(self, version: DuneVersion):
+    def to_str(self, version: DuneVersion) -> str:
         if version == DuneVersion.V1:
             self.as_v1_string()
         if version == DuneVersion.V2:
@@ -77,7 +79,7 @@ def fetch_missing_tokens(dune: DuneClient, network: Network) -> list[Address]:
     query = DuneQuery(
         name="V2: Missing Tokens",
         query_id=1403073,
-        params=[QueryParameter.enum_type("Blockchain", network.dune_v2_repr())],
+        params=[QueryParameter.enum_type("Blockchain", network.as_dune_v2_repr())],
     )
     print(f"Fetching V2 missing tokens for {network} from {query.url()}")
     v2_missing = dune.refresh(query)
@@ -98,7 +100,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     chain: Network = args.network
-    w3 = Web3(Web3.HTTPProvider(chain.node_url()))
+    w3 = Web3(Web3.HTTPProvider(chain.node_url))
 
     missing_tokens = MissingTokenResults(
         v1=fetch_missing_tokens_legacy(DuneClient(os.environ["DUNE_API_KEY"]), chain),

--- a/src/missing_tokens.py
+++ b/src/missing_tokens.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 from dataclasses import dataclass
 from enum import Enum
@@ -6,14 +7,15 @@ import web3.exceptions
 from dotenv import load_dotenv
 from dune_client.client import DuneClient
 from dune_client.query import Query as DuneQuery
+from dune_client.types import QueryParameter
 
 from duneapi.types import Address
 from web3 import Web3
 
 from src.constants import ERC20_ABI
+from src.utils import Network
 
 V1_QUERY = DuneQuery(name="V1: Missing Tokens", query_id=1317323)
-V2_QUERY = DuneQuery(name="V2: Missing Tokens", query_id=1367051)
 
 
 class DuneVersion(Enum):
@@ -23,13 +25,14 @@ class DuneVersion(Enum):
 
 class TokenDetails:
     def __init__(self, address: Address):
-        self.address = address.address
-        token_contract = w3.eth.contract(
-            address=Web3.toChecksumAddress(self.address),
-            abi=ERC20_ABI,
-        )
-        self.symbol = token_contract.caller.symbol()
-        self.decimals = token_contract.caller.decimals()
+        self.address = Web3.toChecksumAddress(address.address)
+        if self.address == Web3.toChecksumAddress("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"):
+            self.symbol = "ETH"
+            self.decimals = 18
+        else:
+            token_contract = w3.eth.contract(address=self.address, abi=ERC20_ABI)
+            self.symbol = token_contract.caller.symbol()
+            self.decimals = token_contract.caller.decimals()
 
     def to_str(self, version: DuneVersion):
         if version == DuneVersion.V1:
@@ -60,25 +63,47 @@ class MissingTokenResults:
         return set(self.v1 + self.v2)
 
 
-def fetch_missing_tokens(dune: DuneClient) -> MissingTokenResults:
-    print(f"Fetching V1 missing tokens from {V1_QUERY.url()}")
-    v1_missing = dune.refresh(V1_QUERY)
-    print(f"Fetching V2 missing tokens from {V2_QUERY.url()}")
-    v2_missing = dune.refresh(V2_QUERY)
-
-    return MissingTokenResults(
-        v1=[Address(row["token"]) for row in v1_missing],
-        v2=[Address(row["token"]) for row in v2_missing],
+def fetch_missing_tokens_legacy(dune: DuneClient, network: Network) -> list[Address]:
+    query = DuneQuery(
+        name="V1: Missing Tokens",
+        query_id={Network.MAINNET: 1317323, Network.GNOSIS: 1403053}[network],
     )
+    print(f"Fetching V1 missing tokens for {network} from {query.url()}")
+    v1_missing = dune.refresh(query)
+    return [Address(row["token"]) for row in v1_missing]
+
+
+def fetch_missing_tokens(dune: DuneClient, network: Network) -> list[Address]:
+    query = DuneQuery(
+        name="V2: Missing Tokens",
+        query_id=1403073,
+        params=[QueryParameter.enum_type("Blockchain", network.dune_v2_repr())],
+    )
+    print(f"Fetching V2 missing tokens for {network} from {query.url()}")
+    v2_missing = dune.refresh(query)
+
+    return [Address(row["token"]) for row in v2_missing]
 
 
 if __name__ == "__main__":
     load_dotenv()
-
-    w3 = Web3(
-        Web3.HTTPProvider(f"https://mainnet.infura.io/v3/{os.environ['INFURA_KEY']}")
+    parser = argparse.ArgumentParser("Missing Tokens")
+    parser.add_argument(
+        "--network",
+        type=Network,
+        choices=list(Network),
+        default=Network.MAINNET,
+        help="Blockchain for which we would like to run this script",
     )
-    missing_tokens = fetch_missing_tokens(DuneClient(os.environ["DUNE_API_KEY"]))
+    args = parser.parse_args()
+
+    chain: Network = args.network
+    w3 = Web3(Web3.HTTPProvider(chain.node_url()))
+
+    missing_tokens = MissingTokenResults(
+        v1=fetch_missing_tokens_legacy(DuneClient(os.environ["DUNE_API_KEY"]), chain),
+        v2=fetch_missing_tokens(DuneClient(os.environ["DUNE_API_KEY"]), chain),
+    )
 
     if not missing_tokens.is_empty():
         print(
@@ -93,8 +118,12 @@ if __name__ == "__main__":
             except web3.exceptions.BadFunctionCallOutput as err:
                 print(f"Something wrong with token {token} - skipping.")
 
-        v1_results = "\n".join(token_details[t].as_v1_string() for t in missing_tokens.v1)
-        v2_results = "\n".join(token_details[t].as_v2_string() for t in missing_tokens.v2)
+        v1_results = "\n".join(
+            token_details[t].as_v1_string() for t in missing_tokens.v1
+        )
+        v2_results = "\n".join(
+            token_details[t].as_v2_string() for t in missing_tokens.v2
+        )
 
         print(f"V1 results:\n\n{v1_results}\n")
         print(f"V2 results:\n\n{v2_results}\n")

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,6 +2,8 @@ import argparse
 import json
 import os
 from datetime import datetime
+from duneapi.types import Network as LegacyDuneNetwork
+from enum import Enum
 
 
 def partition_array(arr: list[any], size: int) -> list[list[any]]:
@@ -22,3 +24,26 @@ def valid_date(s):
     except ValueError:
         msg = "not a valid date: {0!r}".format(s)
         raise argparse.ArgumentTypeError(msg)
+
+
+class Network(Enum):
+    MAINNET = "mainnet"
+    GNOSIS = "gnosis"
+
+    def dune_v1_repr(self) -> LegacyDuneNetwork:
+        return {
+            Network.MAINNET: LegacyDuneNetwork.MAINNET,
+            Network.GNOSIS: LegacyDuneNetwork.GCHAIN,
+        }[self]
+
+    def dune_v2_repr(self) -> str:
+        return {Network.MAINNET: "ethereum", Network.GNOSIS: "gnosis"}[self]
+
+    def node_url(self) -> str:
+        return {
+            Network.MAINNET: f"https://mainnet.infura.io/v3/{os.environ['INFURA_KEY']}",
+            Network.GNOSIS: "https://rpc.gnosischain.com",
+        }[self]
+
+    def chain_id(self) -> int:
+        return {Network.MAINNET: 1, Network.GNOSIS: 100}[self]

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,15 +2,17 @@ import argparse
 import json
 import os
 from datetime import datetime
+from typing import Any
+
 from duneapi.types import Network as LegacyDuneNetwork
 from enum import Enum
 
 
-def partition_array(arr: list[any], size: int) -> list[list[any]]:
+def partition_array(arr: list[Any], size: int) -> list[list[Any]]:
     return [arr[i : i + size] for i in range(0, len(arr), size)]
 
 
-def write_to_json(results: dict[any, any], path: str, filename: str):
+def write_to_json(results: dict[Any, Any], path: str, filename: str) -> None:
     if not os.path.exists(path):
         os.makedirs(path)
     with open(os.path.join(path, filename), "w", encoding="utf-8") as file:
@@ -18,11 +20,11 @@ def write_to_json(results: dict[any, any], path: str, filename: str):
         print(f"Results written to {filename}")
 
 
-def valid_date(s):
+def valid_date(date_str: str) -> datetime:
     try:
-        return datetime.strptime(s, "%Y-%m-%d")
+        return datetime.strptime(date_str, "%Y-%m-%d")
     except ValueError:
-        msg = "not a valid date: {0!r}".format(s)
+        msg = "not a valid date: {0!r}".format(date_str)
         raise argparse.ArgumentTypeError(msg)
 
 
@@ -30,20 +32,22 @@ class Network(Enum):
     MAINNET = "mainnet"
     GNOSIS = "gnosis"
 
-    def dune_v1_repr(self) -> LegacyDuneNetwork:
+    def as_dune_v1_repr(self) -> LegacyDuneNetwork:
         return {
             Network.MAINNET: LegacyDuneNetwork.MAINNET,
             Network.GNOSIS: LegacyDuneNetwork.GCHAIN,
         }[self]
 
-    def dune_v2_repr(self) -> str:
+    def as_dune_v2_repr(self) -> str:
         return {Network.MAINNET: "ethereum", Network.GNOSIS: "gnosis"}[self]
 
+    @property
     def node_url(self) -> str:
         return {
             Network.MAINNET: f"https://mainnet.infura.io/v3/{os.environ['INFURA_KEY']}",
             Network.GNOSIS: "https://rpc.gnosischain.com",
         }[self]
 
+    @property
     def chain_id(self) -> int:
         return {Network.MAINNET: 1, Network.GNOSIS: 100}[self]

--- a/src/utils.py
+++ b/src/utils.py
@@ -28,6 +28,11 @@ def valid_date(date_str: str) -> datetime:
         raise argparse.ArgumentTypeError(msg)
 
 
+class DuneVersion(Enum):
+    V1 = "1"
+    V2 = "2"
+
+
 class Network(Enum):
     MAINNET = "mainnet"
     GNOSIS = "gnosis"

--- a/tests/test_missing_tokens.py
+++ b/tests/test_missing_tokens.py
@@ -1,0 +1,36 @@
+import unittest
+
+from dune_client.types import Address
+
+from src.missing_tokens import MissingTokenResults
+
+
+class TestMissingTokens(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tokens = list(map(Address.from_int, range(3)))
+        print(self.tokens)
+        t0, t1, t2 = self.tokens[0], self.tokens[1], self.tokens[2]
+        self.left = MissingTokenResults(v1=[t0], v2=[])
+        self.right = MissingTokenResults(v1=[], v2=[t1])
+        self.both = MissingTokenResults(v1=[t0], v2=[t1])
+        self.neither = MissingTokenResults(v1=[], v2=[])
+        self.overlap = MissingTokenResults(v1=[t0, t1], v2=[t1, t2])
+
+    def test_is_empty(self):
+        self.assertEqual(self.left.is_empty(), False)
+        self.assertEqual(self.right.is_empty(), False)
+        self.assertEqual(self.both.is_empty(), False)
+        self.assertEqual(self.neither.is_empty(), True)
+        self.assertEqual(self.overlap.is_empty(), False)
+
+    def test_all_tokens(self):
+        t0, t1, t2 = self.tokens[0], self.tokens[1], self.tokens[2]
+        self.assertEqual(self.left.get_all_tokens(), {t0})
+        self.assertEqual(self.right.get_all_tokens(), {t1})
+        self.assertEqual(self.both.get_all_tokens(), {t0, t1})
+        self.assertEqual(self.neither.get_all_tokens(), set())
+        self.assertEqual(self.overlap.get_all_tokens(), {t0, t1, t2})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
We adapt the missing token script for compatibility with Gnosis Chain.

Note that (since we are using the official Dune API)

1. Legacy queries do not have cross chain query compatibility so we have to run a different query per network. This actually was possible with the legacy Dune API (passing the network enum into the query object).

2. V2 query does have crosschain compatibility so we pass `{{Blockchain}}' as a QueryParameter


## Test Plan
Try the Gnosis Chain Query (this does not require an `INFURA_KEY`) because gnosis chain RPC is public access
```
python -m src.missing_tokens --network gnosis
```


Try it out also on mainnet (make sure the original still works)

```sh
python -m src.missing_tokens
```
note that mainnet is the default, but you can also do

```sh
python -m src.missing_tokens --network mainnet
```