### PR TITLE
Extended Token Query

### DIFF
--- a/src/missing_tokens.py
+++ b/src/missing_tokens.py
@@ -42,7 +42,7 @@ def fetch_missing_tokens(dune: DuneClient, network: Network) -> list[Address]:
     """Uses Official DuneAPI and to fetch Missing Tokens"""
     query = DuneQuery(
         name="V3: Missing Tokens on {{Blockchain}}",
-        query_id=2359226,
+        query_id=2444707,
         params=[QueryParameter.enum_type("Blockchain", network.as_dune_v2_repr())],
     )
     print(f"Fetching missing tokens for {network} from {query.url()}")

--- a/src/missing_tokens.py
+++ b/src/missing_tokens.py
@@ -43,7 +43,11 @@ def fetch_missing_tokens(dune: DuneClient, network: Network) -> list[Address]:
     query = DuneQuery(
         name="V3: Missing Tokens on {{Blockchain}}",
         query_id=2444707,
-        params=[QueryParameter.enum_type("Blockchain", network.as_dune_v2_repr())],
+        params=[
+            QueryParameter.enum_type("Blockchain", network.as_dune_v2_repr()),
+            QueryParameter.date_type("DateFrom", "2023-01-01 00:00:00"),
+            QueryParameter.number_type("Popularity", 250),
+        ],
     )
     print(f"Fetching missing tokens for {network} from {query.url()}")
     v2_missing = dune.refresh(query, ping_frequency=10)


### PR DESCRIPTION
Instead of looking for missing tokens on CoW - we use dex.trades. Query has `DateFrom` and `Popularity` (where popularity represents the number of trades involving the corresponding token) parameters to help reduce the scope of results. Defaults are Jan 1, 2023 and 250. 

First run of the query returned ~3k tokens, which says "there are about 3k tokens have been traded at least 250 times since January 1, 2023 with missing details"

cc [This PR](https://github.com/duneanalytics/spellbook/pull/3297)
