### PR TITLE
[Easy] Updated new token insert

### DIFF
--- a/src/missing_tokens.py
+++ b/src/missing_tokens.py
@@ -85,7 +85,7 @@ class TokenDetails:  # pylint:disable=too-few-public-methods
         Example:
           ('0xfcc5c47be19d06bf83eb04298b026f81069ff65b', 'yCRV', 18),
         """
-        return f",('{str(self.address).lower()}', '{self.symbol}', {self.decimals})"
+        return f",({str(self.address).lower()}, '{self.symbol}', {self.decimals})"
 
 
 def fetch_missing_tokens(dune: DuneClient, network: Network) -> list[Address]:


### PR DESCRIPTION
Since Dune has updated to DuneSQL token addresses don't need to be put in string quotes anymore.