### PR TITLE
Catch exception when adding missing tokens

### DIFF
--- a/src/missing_tokens.py
+++ b/src/missing_tokens.py
@@ -102,7 +102,13 @@ def fetch_missing_tokens(dune: DuneClient, network: Network) -> list[Address]:
     print(f"Fetching missing tokens for {network} from {query.url()}")
     v2_missing = dune.refresh(query, ping_frequency=10)
 
-    return [Address(row["token"]) for row in v2_missing.get_rows()]
+    result = []
+    for row in v2_missing.get_rows():
+        try:
+            result.append(Address(row["token"]))
+        except:
+            print("Cannot add token")
+    return result
 
 
 def replace_line(old_line: str, new_line: str, file_loc: str):

--- a/src/missing_tokens.py
+++ b/src/missing_tokens.py
@@ -106,7 +106,7 @@ def fetch_missing_tokens(dune: DuneClient, network: Network) -> list[Address]:
     for row in v2_missing.get_rows():
         try:
             result.append(Address(row["token"]))
-        except:
+        except ValueError:
             print("Cannot add token")
     return result
 


### PR DESCRIPTION
When attempting to generate the list of missing tokens, we observed that the script sometimes crashes due to ill-formed strings/addresses (e.g., addresses that do not have the right length).

This PR addresses this by catching an exception that is raised in this case; whenever the exception is raised, the token is now ignored.